### PR TITLE
add outline-only versions of the OSMC 'pointer' symbol

### DIFF
--- a/test/render_test.py
+++ b/test/render_test.py
@@ -177,6 +177,8 @@ if __name__ == "__main__":
         ('LOC', '', { 'osmc:symbol' : 'red:white:green_L' }),
         ('LOC', '', { 'osmc:symbol' : 'red:white:green_drop' }),
         ('LOC', '', { 'osmc:symbol' : 'red:white:green_drop_line' }),
+        ('LOC', '', { 'osmc:symbol' : 'red:white:green_left_pointer_line' }),
+        ('LOC', '', { 'osmc:symbol' : 'red:white:green_pointer_line' }),
     ]
 
     JEL = ['3', 'but', 'fbor', 'fkor', 'fq', 'fx', 'katlv', 'kivv', 'kor',

--- a/wmt_shields/styles/osmc_symbol.py
+++ b/wmt_shields/styles/osmc_symbol.py
@@ -280,7 +280,31 @@ class OsmcSymbol(RefShieldMaker):
         ctx.line_to(0.9, 0.9)
         ctx.line_to(0.1, 0.5)
         ctx.fill()
-        
+
+    def paint_fg_pointer_line(self, ctx):
+        ctx.set_line_width(0.15)
+        ctx.move_to(0.1, 0.1)
+        ctx.line_to(0.1, 0.9)
+        ctx.line_to(0.9, 0.5)
+        ctx.line_to(0.1, 0.1)
+        ctx.stroke()
+
+    def paint_fg_right_pointer_line(self, ctx):
+        ctx.set_line_width(0.15)
+        ctx.move_to(0.1, 0.1)
+        ctx.line_to(0.1, 0.9)
+        ctx.line_to(0.9, 0.5)
+        ctx.line_to(0.1, 0.1)
+        ctx.stroke()
+
+    def paint_fg_left_pointer_line(self, ctx):
+        ctx.set_line_width(0.15)
+        ctx.move_to(0.9, 0.1)
+        ctx.line_to(0.9, 0.9)
+        ctx.line_to(0.1, 0.5)
+        ctx.line_to(0.9, 0.1)
+        ctx.stroke()
+
     def paint_fg_rectangle_line(self, ctx):
         ctx.set_line_width(0.15)
         ctx.rectangle(0.25, 0.25, 0.5, 0.5)


### PR DESCRIPTION
Adding three new symbols - line versions of the "pointer" symbols:   pointer_line, left_pointer_line, right_pointer_line.

As suggested in https://community.openstreetmap.org/t/brauche-hilfe-fur-wanderweg-symbol/122926